### PR TITLE
console is a builtin

### DIFF
--- a/lib/exclusions.js
+++ b/lib/exclusions.js
@@ -20,7 +20,9 @@ exports.invalid = [
  * Required modules to exclude
  */
 
-exports.builtins = require('repl')._builtinLibs;
+exports.builtins = require('repl')._builtinLibs.concat([
+  'console'  
+]);
 
 // Final omissions. These can give false-negatives,
 // since tools like load-grunt-tasks obscure the


### PR DESCRIPTION
The repl does not include console because its a global and doesnt want to shadow it. This a REPL specific thing.